### PR TITLE
Upgrade to v1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,6 @@ Imports:
     rlang,
     shiny,
     shinyjs,
-    stringr,
     UU
 Remotes:
   yogat3ch/UU


### PR DESCRIPTION
This creates a new version of the package that:
 - provides defaults for the `session` argument as standard shiny server functions do
 - provides a new set of snakecase named functions
 - splits the editor into a ui/server portion `editor_ui/editor_server`
 - allows options to be passed as an R list
 - automatically writes textarea content to an input if `inputId` argument is passed to `editor_server`
 - new functions are compatible with modularized apps (automatically namespaces ids)
 - new functions are compatible with modalDialog,  re-rendering via renderUI, and show/hiding the textarea (previous functions are not). `modalDialog` usage has not been fully tested.
 - updates the examples ( _-v1_ appended to the filenames of new examples)